### PR TITLE
libboost_test is not listed as a requirement and not checked for existence in CMake.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,12 @@ Building from Source (using cmake)
   2. Run:
 
     $ cmake .
-    $ make
+    $ make c10t
 
   note: CMake should generate a file called src/config.h from the input file src/config.h.cmake
+  note: There are several executables you can make.  c10t, c10t-lib, c10t-debug, and c10t-test.
+        If you wish to build all of these simply run `make`.  If you wish to build and individual
+        one run `make <executable>` e.g. `make c10t-test`.
 
   3. The executable (`c10t`) will be in the current directory.
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(c10t-test EXCLUDE_FROM_ALL test.cpp)
+add_executable(c10t-test test.cpp)
 
 target_link_libraries(c10t-test c10t-lib)
 target_link_libraries(c10t-test ${c10t_LIBRARIES})


### PR DESCRIPTION
I added it under requirements, added it to the ubuntu install line, and added the test for it in CMake.
