### PR TITLE
Improved broad phase scan by parsing filenames

### DIFF
--- a/src/Level.h
+++ b/src/Level.h
@@ -13,12 +13,17 @@
 #include <zlib.h>
 #include <time.h>
 
+#include <boost/detail/atomic_count.hpp>
+#include <boost/thread/mutex.hpp>
+#include <boost/thread/condition.hpp>
+
 #include "nbt/nbt.h"
 
 #include "Color.h"
 #include "Image.h"
 #include "blocks.h"
 
+bool parse_filename_coordinates(const std::string& path, int& x, int& z);
 void transform_world_xz(int& x, int& z, int rotation);
 
 class Level
@@ -36,14 +41,24 @@ class Level
     size_t grammar_error_where;
     std::string grammar_error_why;
     std::string path;
-    bool ignore_blocks;
 
-    Level(const char *path, bool ignore_blocks);
+    Level(settings_t& s, const std::string& path);
     ~Level();
 
     ImageBuffer *get_image(settings_t& s);
     ImageBuffer *get_oblique_image(settings_t& s);
     ImageBuffer *get_obliqueangle_image(settings_t& s);
+
+    void load_data(settings_t& s);
+    void unload_data();
+
+  private:
+    boost::mutex load_mutex;
+    boost::detail::atomic_count load_count;
+    bool load_tried;
+
+    // Private and not implemented so it can't be used (avoids copies).
+    Level(const Level& other);
 };
 
 #endif /* _LEVEL_H_ */

--- a/src/fileutils.cpp
+++ b/src/fileutils.cpp
@@ -2,6 +2,8 @@
 
 #include <sys/stat.h>
 
+#include <boost/algorithm/string.hpp>
+
 #ifdef _WIN32
 const char *dir_sep = "\\";
 const char dir_sep_c = '\\';
@@ -24,4 +26,11 @@ bool is_file(std::string &path) {
 
 std::string path_join(std::string a, std::string b) {
   return a + dir_sep + b;
+}
+
+std::vector<std::string> path_split(std::string path)
+{
+  std::vector<std::string> result;
+  boost::split(result, path, boost::is_any_of(dir_sep));
+  return result;
 }

--- a/src/fileutils.h
+++ b/src/fileutils.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <queue>
+#include <vector>
 
 #include <dirent.h>
 
@@ -11,6 +12,8 @@ bool is_dir(std::string &path);
 bool is_file(std::string &path);
 
 std::string path_join(std::string a, std::string b);
+
+std::vector<std::string> path_split(std::string path);
 
 class dirlist {
 private:


### PR DESCRIPTION
This is a fairly large set of changes, so let me know if you have any questions or want me to change anything. I tried to split it some cleanup into separate commits, but the last commit is still pretty big.

The new code eliminates the initial file parsing of all data files and grabs X and Z coordinates from the filename instead. On my test map with over 37000 chunks this reduces the drawing time from 35 to 22 seconds. This is after the map data has been previously cached by the system, otherwise the whole process takes several minutes anyway. The biggest win is when drawing small sections of a large map, since the directory scan is very quick, and only a few files need to be loaded for drawing.
