### PR TITLE
Add 'system' to list of Boost libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(ZLIB REQUIRED)
 find_package(PNG REQUIRED)
 find_package(FreeType REQUIRED)
 find_package(Threads REQUIRED)
-find_package(Boost COMPONENTS thread filesystem REQUIRED)
+find_package(Boost COMPONENTS thread filesystem system REQUIRED)
 
 include_directories(${ZLIB_INCLUDE_DIR})
 include_directories(${PNG_INCLUDE_DIR})


### PR DESCRIPTION
Without the 'system' Boost library, the linker fails as pointed out here:
http://minecraftforum.net/viewtopic.php?f=25&t=33803&start=150#p735302
