### PR TITLE
JSON workaround

### DIFF
--- a/scripts/google-api/google-api.sh
+++ b/scripts/google-api/google-api.sh
@@ -214,6 +214,13 @@ for t in $TILE_SIZES; do
   generate "-n" "night" $t $z $s
 done
 
+# fix to correct center-x and center-y missing
+sed -i s/cx/center-x/g $target/day.json
+sed -i s/cy/center-y/g $target/day.json
+sed -i s/cx/center-x/g $target/night.json
+sed -i s/cy/center-y/g $target/night.json
+# end fix
+
 cat > $target/options.js << ENDL
 var options = {
   host: "$host$tiles/",


### PR DESCRIPTION
My change to the google-api.sh fixes the black screen issue that is currently being produced by HEAD.

I'm not sure why the script is generating cx and cy instead of center-x and center-y ... so without digging into the code further, this at least makes the script work properly out of the box.
