### PR TITLE
PNG info_struct leak, Region.hpp cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *~
 *.pyc
+*.a
+*.cmake
+CMakeFiles
 build

--- a/src/image/format/png.hpp
+++ b/src/image/format/png.hpp
@@ -115,15 +115,10 @@ class png_format {
       {
         fclose(fp);
       }
-       
-      if (info_ptr != NULL)
-      {
-        png_free_data(png_ptr, info_ptr, PNG_FREE_ALL, -1);
-      }
 
       if (png_ptr != NULL)
       {
-        png_destroy_write_struct(&png_ptr, (png_infopp)NULL);
+        png_destroy_write_struct(&png_ptr, &info_ptr);
       }
 
       if (row != NULL)


### PR DESCRIPTION
There was a minor leak with how PNG cleanup was handled.

Added a sanity check for the chunk length, and allocated in/out on the stack instead of heap. Should help a bit.

Making read_data not return-by-value might give a slight speedup.
