### PR TITLE
Fix a build error I was experiencing with HEAD

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -193,7 +193,7 @@ inline void overlay_markers(settings_t& s, boost::shared_ptr<image_base> all, bo
 
 template<typename T>
 void cout_dot(T total) {
-  if (total == 0) out << " done!";
+  if ((int)total == 0) out << " done!";
   else out << "." << flush;
 }
 


### PR DESCRIPTION
Trying to build main.cpp, I was getting a "ambiguous overload for 'operator=='" build error in main.cpp:

/root/c10t/src/main.cpp:196: error: ambiguous overload for 'operator==' in 'total == 0'
/root/c10t/src/main.cpp:196: note: candidates are: operator==(std::streamoff, int) <built-in>

Casting total to int before trying to compare to 0 cleared it up.
