### PR TITLE
Fix for Boost 1.46.1 (filesystem library 3) compile error

### DIFF
--- a/src/fileutils.hpp
+++ b/src/fileutils.hpp
@@ -54,7 +54,7 @@ public:
           directories.push(itr->path());
         }
         else if (fs::is_regular_file(itr->status())) {
-          if (!file_filter(itr->path().filename())) {
+          if (!file_filter(itr->path().filename().string())) {
             continue;
           }
           


### PR DESCRIPTION
Boost 1.46.1 uses the new filesystem library version 3. This one line change allows c10t to be compiled on systems using Filesystem Library version 3. Future versions of boost will use it as well.
