### PR TITLE
Include <zlib.h> where needed to avoid compile error.

### DIFF
--- a/src/image/format/png.hpp
+++ b/src/image/format/png.hpp
@@ -2,6 +2,7 @@
 #define FILEFORMAT_PNG
 
 #include <png.h>
+#include <zlib.h>
 
 #include "image/image_base.hpp"
 


### PR DESCRIPTION
This fixes the initial bug reported as issue #194, though not the second problem in that ticket.
