### PR TITLE
Add an option to allow removing the matching prefix from sign texts before rendering

### DIFF
--- a/src/global.hpp
+++ b/src/global.hpp
@@ -60,6 +60,7 @@ struct settings_t {
   bool show_signs;
   bool show_warps;
   bool silent;
+  bool strip_sign_prefix;
   bool striped_terrain;
   bool use_split;
   bool write_js;
@@ -137,6 +138,7 @@ struct settings_t {
     this->show_players = false;
     this->show_coordinates = false;
     this->show_signs = false;
+    this->strip_sign_prefix = false;
     this->show_warps = false;
     this->require_all = false;
     this->striped_terrain = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -322,7 +322,11 @@ inline void push_sign_markers(settings_t& s, text::font_face base_font, S& signs
       continue;
     }
     
-    markers.push_back(new marker(lm.text, "sign", sign_font, lm.x, lm.y, lm.z));
+    if (!s.strip_sign_prefix) {
+      markers.push_back(new marker(lm.text, "sign", sign_font, lm.x, lm.y, lm.z));
+    } else {
+      markers.push_back(new marker(lm.text.substr(s.show_signs_filter.size()), "sign", sign_font, lm.x, lm.y, lm.z));
+    }
   }
 }
 
@@ -1217,6 +1221,7 @@ int do_help() {
     << "  --show-signs[=PREFIX]     - Will draw out signs from all chunks, if PREFIX   " << endl
     << "                              is specified, only signs matching the prefix will" << endl
     << "                              be drawn                                         " << endl
+    << "  --strip-sign-prefix       - When drawing sign text, removes the match prefix " << endl
     << "  --show-warps=<file>       - Will draw out warp positions from the specified  " << endl
     << "                              warps.txt file, as used by hey0's mod            " << endl
     << "  --show-coordinates        - Will draw out each chunks expected coordinates   " << endl

--- a/src/main_utils.cpp
+++ b/src/main_utils.cpp
@@ -333,6 +333,7 @@ struct option long_options[] =
     {"disable-skylight",                    no_argument,         &flag,   26},
     {"center",                              required_argument,   &flag,   30},
     {"graph-block",                         required_argument,   &flag,   31},
+    {"strip-sign-prefix",                   no_argument,         &flag,   32},
     {0,                                     0,                   0,       0}
 };
 
@@ -558,6 +559,10 @@ bool read_opts(settings_t& s, int argc, char* argv[])
         {
             return false;
         }
+        break;
+
+      case 32:
+        s.strip_sign_prefix = true;
         break;
       }
       


### PR DESCRIPTION
When using the prefix-match option of --show-signs, clearly the intent is for the players in the world to create signs that can be seen in the rendered map while not forcing every sign to be visible. However, it doesn't necessarily make sense to force the prefix text to actually be rendered into the map; sometimes, you want the prefix text to identify a sign to be rendered but you don't actually want the prefix to appear in the world. This patch adds the "--strip-sign-prefix" option which, when used with --show-signs and a prefix match, removes exactly the matched prefix from the sign text before rendering.
