### PR TITLE
Add some missing includes.

### DIFF
--- a/src/nbt/types.hpp
+++ b/src/nbt/types.hpp
@@ -1,6 +1,9 @@
 #ifndef _NBT_TYPES_HPP
 #define _NBT_TYPES_HPP
 
+#include <stdint.h>
+#include <string>
+
 namespace nbt {
   typedef int8_t Byte;
   typedef int16_t Short;


### PR DESCRIPTION
These includes are missing. I managed to get a compile failure (specifically, "field 'name' has incomplete type") when src/engine/functions.cpp includes src/engine/functions.hpp, which includes src/engine/block_rotation.hpp, which includes src/nbt/types.hpp without including the STL "string" header. Stdint.h is included elsewhere in this chain but for completeness I included it in nbt/types.hpp to make header self-contained.
