### PR TITLE
Fixed third party blocks causing crashes

### DIFF
--- a/src/engine/flat_base.hpp
+++ b/src/engine/flat_base.hpp
@@ -64,7 +64,7 @@ public:
             int block_type = br_blocks.get8(y);
             int block_data = br_data.get4(y);
 
-            if (s.excludes[block_type]) {
+            if (block_type >=0 && s.excludes[block_type]) {
               continue;
             }
 

--- a/src/engine/isometric_base.hpp
+++ b/src/engine/isometric_base.hpp
@@ -50,7 +50,7 @@ public:
           
             int block_type = br_blocks.get8(y);
             
-            if (s.excludes[block_type]) {
+            if (block_type >=0 && s.excludes[block_type]) {
               continue;
             }
             


### PR DESCRIPTION
Thanks to comments on my issue from Ben0mega, I've made two simple changes that seems to have resolved my issue. I am able to successfully render maps that contain modded blocks and items again without issues.
