### PR TITLE
Add missing include.

### DIFF
--- a/src/nbt/nbt.hpp
+++ b/src/nbt/nbt.hpp
@@ -14,6 +14,7 @@
 #include <string>
 #include <stack>
 #include <list>
+#include <iostream>
 
 #include <boost/ptr_container/ptr_vector.hpp>
 #include <boost/shared_ptr.hpp>


### PR DESCRIPTION
std::cerr is used in a few places; in a debug build iostream seems to be included from one of the other headers, but in a release built it isn't, so it should be included here.
