### PR TITLE
Fixed incorrect color type conversion

### DIFF
--- a/src/main_utils.cpp
+++ b/src/main_utils.cpp
@@ -104,10 +104,10 @@ bool parse_color(const string value, color& c)
         return false;
     }
     
-    c.r = cr;
-    c.g = cg;
-    c.b = cb;
-    c.a = ca;
+    c.r = color_i_to_f[cr];
+    c.g = color_i_to_f[cg];
+    c.b = color_i_to_f[cb];
+    c.a = color_i_to_f[ca];
     
     return true;
 }


### PR DESCRIPTION
Fixed incorrect color type conversion preventing command line color parameters from being parsed correctly to colors.
