### PR TITLE
Repaired -W option

### DIFF
--- a/src/image/color.hpp
+++ b/src/image/color.hpp
@@ -104,7 +104,7 @@ struct color{
   friend std::ostream& operator<<(std::ostream& out, const color& c) // output
   {
     std::stringstream ss;
-    ss << (int)c.r << "," << (int)c.g << "," << (int)c.b << "," << (int)c.a;
+    ss << (int)roundf(c.r*255.0f) << "," << (int)roundf(c.g*255.0f) << "," << (int)roundf(c.b*255.0f) << "," << (int)roundf(c.a*255.0f);
     out << ss.str();
     return out;
   }


### PR DESCRIPTION
https://github.com/udoprog/c10t/commit/233149472569a73c1a4ad7204f85590e90ad85e1 changed the color value range from values between 0.0f and 255.0f to values between 0.0f and 1.0f. Casting these values to int will thus only create 0 and 1. This patch recalculates the original int values so they can be saved in a human readable/editable way.
